### PR TITLE
fix: add mandatory tier property when creating a new supabase org.

### DIFF
--- a/provider/pkg/provider/organizations/organization.go
+++ b/provider/pkg/provider/organizations/organization.go
@@ -28,6 +28,8 @@ type Organization struct{}
 type OrganizationArgs struct {
 	// The name of the organization to create, if not provided one will be generated from the resource name
 	Name string `pulumi:"name,optional"`
+
+	Tier string `pulumi:"tier"`
 }
 
 // Each resource has a state, describing the fields that exist on the created resource.
@@ -56,12 +58,14 @@ func (Organization) Create(ctx p.Context, name string, input OrganizationArgs, p
 		orgName = input.Name
 	}
 
+	tier := supabase.CreateOrganizationBodyV2Tier(input.Tier)
+
 	resp, err := supabaseClient.CreateOrganizationWithTier(ctx, supabase.CreateOrganizationBodyV2{
 		Name: orgName,
 		Kind: lo.ToPtr("PERSONAL"),
 		// TODO: The v0 API doesn't accept billing information
 		// So orgs will be created with legacy billing until updated
-		// Tier: supabase.TierFree,
+		Tier: &tier,
 	})
 	if err != nil {
 		return name, state, err

--- a/sdk/dotnet/Organizations/Organization.cs
+++ b/sdk/dotnet/Organizations/Organization.cs
@@ -24,6 +24,9 @@ namespace Pulumi.Supabase.Organizations
         [Output("organization_slug")]
         public Output<string> Organization_slug { get; private set; } = null!;
 
+        [Output("tier")]
+        public Output<string> Tier { get; private set; } = null!;
+
 
         /// <summary>
         /// Create a Organization resource with the given unique name, arguments, and options.
@@ -32,7 +35,7 @@ namespace Pulumi.Supabase.Organizations
         /// <param name="name">The unique name of the resource</param>
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
-        public Organization(string name, OrganizationArgs? args = null, CustomResourceOptions? options = null)
+        public Organization(string name, OrganizationArgs args, CustomResourceOptions? options = null)
             : base("supabase:organizations:Organization", name, args ?? new OrganizationArgs(), MakeResourceOptions(options, ""))
         {
         }
@@ -71,6 +74,9 @@ namespace Pulumi.Supabase.Organizations
     {
         [Input("name")]
         public Input<string>? Name { get; set; }
+
+        [Input("tier", required: true)]
+        public Input<string> Tier { get; set; } = null!;
 
         public OrganizationArgs()
         {

--- a/sdk/go/supabase/organizations/organization.go
+++ b/sdk/go/supabase/organizations/organization.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"reflect"
 
+	"errors"
 	"github.com/nitrictech/pulumi-supabase/sdk/v3/go/supabase/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -18,15 +19,19 @@ type Organization struct {
 	Organization_id   pulumi.IntOutput       `pulumi:"organization_id"`
 	Organization_name pulumi.StringOutput    `pulumi:"organization_name"`
 	Organization_slug pulumi.StringOutput    `pulumi:"organization_slug"`
+	Tier              pulumi.StringOutput    `pulumi:"tier"`
 }
 
 // NewOrganization registers a new resource with the given unique name, arguments, and options.
 func NewOrganization(ctx *pulumi.Context,
 	name string, args *OrganizationArgs, opts ...pulumi.ResourceOption) (*Organization, error) {
 	if args == nil {
-		args = &OrganizationArgs{}
+		return nil, errors.New("missing one or more required arguments")
 	}
 
+	if args.Tier == nil {
+		return nil, errors.New("invalid value for required argument 'Tier'")
+	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource Organization
 	err := ctx.RegisterResource("supabase:organizations:Organization", name, args, &resource, opts...)
@@ -61,11 +66,13 @@ func (OrganizationState) ElementType() reflect.Type {
 
 type organizationArgs struct {
 	Name *string `pulumi:"name"`
+	Tier string  `pulumi:"tier"`
 }
 
 // The set of arguments for constructing a Organization resource.
 type OrganizationArgs struct {
 	Name pulumi.StringPtrInput
+	Tier pulumi.StringInput
 }
 
 func (OrganizationArgs) ElementType() reflect.Type {
@@ -169,6 +176,10 @@ func (o OrganizationOutput) Organization_name() pulumi.StringOutput {
 
 func (o OrganizationOutput) Organization_slug() pulumi.StringOutput {
 	return o.ApplyT(func(v *Organization) pulumi.StringOutput { return v.Organization_slug }).(pulumi.StringOutput)
+}
+
+func (o OrganizationOutput) Tier() pulumi.StringOutput {
+	return o.ApplyT(func(v *Organization) pulumi.StringOutput { return v.Tier }).(pulumi.StringOutput)
 }
 
 type OrganizationArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/nodejs/organizations/organization.ts
+++ b/sdk/nodejs/organizations/organization.ts
@@ -35,6 +35,7 @@ export class Organization extends pulumi.CustomResource {
     public /*out*/ readonly organization_id!: pulumi.Output<number>;
     public /*out*/ readonly organization_name!: pulumi.Output<string>;
     public /*out*/ readonly organization_slug!: pulumi.Output<string>;
+    public readonly tier!: pulumi.Output<string>;
 
     /**
      * Create a Organization resource with the given unique name, arguments, and options.
@@ -43,11 +44,15 @@ export class Organization extends pulumi.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param opts A bag of options that control this resource's behavior.
      */
-    constructor(name: string, args?: OrganizationArgs, opts?: pulumi.CustomResourceOptions) {
+    constructor(name: string, args: OrganizationArgs, opts?: pulumi.CustomResourceOptions) {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
+            if ((!args || args.tier === undefined) && !opts.urn) {
+                throw new Error("Missing required property 'tier'");
+            }
             resourceInputs["name"] = args ? args.name : undefined;
+            resourceInputs["tier"] = args ? args.tier : undefined;
             resourceInputs["organization_id"] = undefined /*out*/;
             resourceInputs["organization_name"] = undefined /*out*/;
             resourceInputs["organization_slug"] = undefined /*out*/;
@@ -56,6 +61,7 @@ export class Organization extends pulumi.CustomResource {
             resourceInputs["organization_id"] = undefined /*out*/;
             resourceInputs["organization_name"] = undefined /*out*/;
             resourceInputs["organization_slug"] = undefined /*out*/;
+            resourceInputs["tier"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(Organization.__pulumiType, name, resourceInputs, opts);
@@ -67,4 +73,5 @@ export class Organization extends pulumi.CustomResource {
  */
 export interface OrganizationArgs {
     name?: pulumi.Input<string>;
+    tier: pulumi.Input<string>;
 }

--- a/sdk/python/pulumi_supabase/organizations/organization.py
+++ b/sdk/python/pulumi_supabase/organizations/organization.py
@@ -14,12 +14,23 @@ __all__ = ['OrganizationArgs', 'Organization']
 @pulumi.input_type
 class OrganizationArgs:
     def __init__(__self__, *,
+                 tier: pulumi.Input[str],
                  name: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a Organization resource.
         """
+        pulumi.set(__self__, "tier", tier)
         if name is not None:
             pulumi.set(__self__, "name", name)
+
+    @property
+    @pulumi.getter
+    def tier(self) -> pulumi.Input[str]:
+        return pulumi.get(self, "tier")
+
+    @tier.setter
+    def tier(self, value: pulumi.Input[str]):
+        pulumi.set(self, "tier", value)
 
     @property
     @pulumi.getter
@@ -37,6 +48,7 @@ class Organization(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  name: Optional[pulumi.Input[str]] = None,
+                 tier: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
         Create a Organization resource with the given unique name, props, and options.
@@ -47,7 +59,7 @@ class Organization(pulumi.CustomResource):
     @overload
     def __init__(__self__,
                  resource_name: str,
-                 args: Optional[OrganizationArgs] = None,
+                 args: OrganizationArgs,
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Create a Organization resource with the given unique name, props, and options.
@@ -67,6 +79,7 @@ class Organization(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  name: Optional[pulumi.Input[str]] = None,
+                 tier: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -77,6 +90,9 @@ class Organization(pulumi.CustomResource):
             __props__ = OrganizationArgs.__new__(OrganizationArgs)
 
             __props__.__dict__["name"] = name
+            if tier is None and not opts.urn:
+                raise TypeError("Missing required property 'tier'")
+            __props__.__dict__["tier"] = tier
             __props__.__dict__["organization_id"] = None
             __props__.__dict__["organization_name"] = None
             __props__.__dict__["organization_slug"] = None
@@ -106,6 +122,7 @@ class Organization(pulumi.CustomResource):
         __props__.__dict__["organization_id"] = None
         __props__.__dict__["organization_name"] = None
         __props__.__dict__["organization_slug"] = None
+        __props__.__dict__["tier"] = None
         return Organization(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -127,4 +144,9 @@ class Organization(pulumi.CustomResource):
     @pulumi.getter
     def organization_slug(self) -> pulumi.Output[str]:
         return pulumi.get(self, "organization_slug")
+
+    @property
+    @pulumi.getter
+    def tier(self) -> pulumi.Output[str]:
+        return pulumi.get(self, "tier")
 


### PR DESCRIPTION
Update to add required tier property for supabase management API when creating new Organisations. 